### PR TITLE
Feature/string builder cache

### DIFF
--- a/Diacritical.Benchmark/Diacritical.Benchmark.csproj
+++ b/Diacritical.Benchmark/Diacritical.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Diacritical.Benchmark/Diacritical.Benchmark.csproj
+++ b/Diacritical.Benchmark/Diacritical.Benchmark.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Diacritics" Version="2.1.20036.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Diacritics" Version="3.3.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Diacritical.Benchmark/Diacritical.Benchmark.csproj
+++ b/Diacritical.Benchmark/Diacritical.Benchmark.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Diacritics" Version="2.0.18316.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Diacritics" Version="2.1.20036.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Diacritical.Benchmark/HasDiacriticsBenchmark.cs
+++ b/Diacritical.Benchmark/HasDiacriticsBenchmark.cs
@@ -6,6 +6,7 @@ namespace Diacritical.Benchmark
 	[ShortRunJob]
 	[CsvExporter(CsvSeparator.Comma)]
 	[RankColumn]
+    [MemoryDiagnoser]
 	public class HasDiacriticsBenchmark
 	{
 

--- a/Diacritical.Benchmark/RemoveDiacriticsBenchmark.cs
+++ b/Diacritical.Benchmark/RemoveDiacriticsBenchmark.cs
@@ -6,6 +6,7 @@ namespace Diacritical.Benchmark
 	[ShortRunJob]
 	[CsvExporter(CsvSeparator.Comma)]
 	[RankColumn]
+    [MemoryDiagnoser]
 	public class RemoveDiacriticsBenchmark
 	{
 

--- a/Diacritical.Benchmark/RemoveDiacriticsBenchmark.cs
+++ b/Diacritical.Benchmark/RemoveDiacriticsBenchmark.cs
@@ -32,7 +32,7 @@ namespace Diacritical.Benchmark
 
 		#endregion
 
-		#region
+		#region Diacritics
 
 		[Benchmark]
 		public string Diacritics_ShortLatinOnlyString() => Diacritics.Extensions.StringExtensions.RemoveDiacritics(Constants.ShortLatinString);

--- a/Diacritical.Import/Diacritical.Import.csproj
+++ b/Diacritical.Import/Diacritical.Import.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Diacritical.Import/Diacritical.Import.csproj
+++ b/Diacritical.Import/Diacritical.Import.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
 
 </Project>

--- a/Diacritical.Import/Program.cs
+++ b/Diacritical.Import/Program.cs
@@ -2,111 +2,110 @@
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Diacritical.Import
 {
-	class Program
-	{
-		private const string Endpoint = "https://raw.githubusercontent.com/diacritics/database/dist/v1/diacritics.json";
+    class Program
+    {
+        private const string Endpoint = "https://raw.githubusercontent.com/diacritics/database/dist/v1/diacritics.json";
 
-		static async Task Main(string[] args)
-		{
-			using (var client = new HttpClient())
-			{
-				var json = await client.GetStringAsync(Endpoint);
-				var diacriticsMap = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, CultureVariation>>>(json);
-				var mappings = diacriticsMap.Values.SelectMany(x => x.Values.SelectMany(z => z.Variations.Values))
-					.SelectMany(x => x.Equivalents.Select(a => (a.Raw, Base: x.Mapping.Base ?? x.Mapping.Decompose?.Value)))
-					.Where(x=> !string.IsNullOrEmpty(x.Base) && char.TryParse(x.Raw, out _))
-					.OrderBy(x=> x.Raw)
-					.ToArray();
+        static async Task Main()
+        {
+            using var client = new HttpClient();
+            var json = await client.GetStringAsync(Endpoint);
+            var diacriticsMap = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, CultureVariation>>>(json) ?? new();
+            var mappings = diacriticsMap.Values.SelectMany(x => x.Values.SelectMany(z => z.Variations.Values))
+                .SelectMany(x => x.Equivalents.Select(a => (a.Raw, Base: x.Mapping.Base ?? x.Mapping.Decompose?.Value)))
+                .Where(x => !string.IsNullOrEmpty(x.Base) && char.TryParse(x.Raw, out _))
+                .OrderBy(x => x.Raw)
+                .ToArray();
 
-				File.WriteAllLines("mappings.txt", mappings.Select(x=> $"{{ '{x.Raw}', \"{x.Base}\" }},"));
-			}
-		}
+            await File.WriteAllLinesAsync("mappings.txt", mappings.Select(x => $"{{ '{x.Raw}', \"{x.Base}\" }},"));
+        }
 
-		#region Models
+        #region Models
 
-		public class Metadata
-		{
-			[JsonProperty("alphabet")]
-			public string Alphabet { get; set; }
+        public class Metadata
+        {
+            [JsonPropertyName("alphabet")]
+            public string Alphabet { get; set; }
 
-			[JsonProperty("continent")]
-			public IList<string> Continent { get; set; }
+            [JsonPropertyName("continent")]
+            public IList<string> Continent { get; set; }
 
-			[JsonProperty("language")]
-			public string Language { get; set; }
+            [JsonPropertyName("language")]
+            public string Language { get; set; }
 
-			[JsonProperty("languageNative")]
-			public string LanguageNative { get; set; }
+            [JsonPropertyName("languageNative")]
+            public string LanguageNative { get; set; }
 
-			[JsonProperty("source")]
-			public IList<string> Source { get; set; }
+            [JsonPropertyName("source")]
+            public IList<string> Source { get; set; }
 
-			[JsonProperty("country")]
-			public IList<string> Country { get; set; }
-		}
+            [JsonPropertyName("country")]
+            public IList<string> Country { get; set; }
+        }
 
-		public class Decompose
-		{
-			[JsonProperty("value")]
-			public string Value { get; set; }
-		}
+        public class Decompose
+        {
+            [JsonPropertyName("value")]
+            public string Value { get; set; }
+        }
 
-		public class Mapping
-		{
+        public class Mapping
+        {
 
-			[JsonProperty("base")]
-			public string Base { get; set; }
+            [JsonPropertyName("base")]
+            public string Base { get; set; }
 
-			[JsonProperty("decompose")]
-			public Decompose Decompose { get; set; }
-		}
+            [JsonPropertyName("decompose")]
+            public Decompose Decompose { get; set; }
+        }
 
-		public class Equivalent
-		{
-			[JsonProperty("raw")]
-			public string Raw { get; set; }
+        public class Equivalent
+        {
+            [JsonPropertyName("raw")]
+            public string Raw { get; set; }
 
-			[JsonProperty("unicode")]
-			public string Unicode { get; set; }
+            [JsonPropertyName("unicode")]
+            public string Unicode { get; set; }
 
-			[JsonProperty("htmlDecimal")]
-			public string HtmlDecimal { get; set; }
+            [JsonPropertyName("htmlDecimal")]
+            public string HtmlDecimal { get; set; }
 
-			[JsonProperty("htmlHex")]
-			public string HtmlHex { get; set; }
+            [JsonPropertyName("htmlHex")]
+            public string HtmlHex { get; set; }
 
-			[JsonProperty("encodedUri")]
-			public string EncodedUri { get; set; }
-		}
+            [JsonPropertyName("encodedUri")]
+            public string EncodedUri { get; set; }
+        }
 
-		public class Variation
-		{
+        public class Variation
+        {
 
-			[JsonProperty("case")]
-			public string Case { get; set; }
+            [JsonPropertyName("case")]
+            public string Case { get; set; }
 
-			[JsonProperty("mapping")]
-			public Mapping Mapping { get; set; }
+            [JsonPropertyName("mapping")]
+            public Mapping Mapping { get; set; }
 
-			[JsonProperty("equivalents")]
-			public IList<Equivalent> Equivalents { get; set; }
-		}
+            [JsonPropertyName("equivalents")]
+            public IList<Equivalent> Equivalents { get; set; }
+        }
 
-		public class CultureVariation
-		{
-			[JsonProperty("metadata")]
-			public Metadata Metadata { get; set; }
+        public class CultureVariation
+        {
+            [JsonPropertyName("metadata")]
+            public Metadata Metadata { get; set; }
 
-			[JsonProperty("data")]
-			public Dictionary<string, Variation> Variations { get; set; }
-		}
-		
-		#endregion
+            [JsonPropertyName("data")]
+            public Dictionary<string, Variation> Variations { get; set; }
+        }
 
-	}
+        #endregion
+
+    }
 }

--- a/Diacritical.Test/DiacriticProviderTests.cs
+++ b/Diacritical.Test/DiacriticProviderTests.cs
@@ -23,7 +23,7 @@ namespace Diacritical.Test
 			var subject = "ₓ";
 
 			var result = subject.RemoveDiacritics();
-			Assert.AreEqual(x_lower.ToLower(), result);
+			Assert.AreEqual(x_lower, result);
 
 			DiacriticMap.AddProvider(new CustomDiacriticProvider(new Dictionary<char, string>
 			{
@@ -31,7 +31,7 @@ namespace Diacritical.Test
 			}));
 
 			result = subject.RemoveDiacritics();
-			Assert.AreEqual(x_upper.ToUpper(), result);
+			Assert.AreEqual(x_upper, result);
 		}
 
 	}

--- a/Diacritical.Test/Diacritical.Test.csproj
+++ b/Diacritical.Test/Diacritical.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Diacritical.Test/Diacritical.Test.csproj
+++ b/Diacritical.Test/Diacritical.Test.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Diacritical.Test/Diacritical.Test.csproj
+++ b/Diacritical.Test/Diacritical.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Diacritical/DiacriticIndex.cs
+++ b/Diacritical/DiacriticIndex.cs
@@ -5,8 +5,8 @@ namespace Diacritical
 	internal class DiacriticIndex
 	{
 		public DiacriticIndex(IReadOnlyDictionary<char, string> map)
-		{
-			Map = map;
+        {
+            Map = map;
 		}
 
 		public IReadOnlyDictionary<char, string> Map { get; }

--- a/Diacritical/Diacritical.csproj
+++ b/Diacritical/Diacritical.csproj
@@ -13,7 +13,7 @@
 		<Product>Diacritical</Product>
     <PackageTags>diacritic;string-formatting;accent</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/anth12/diacritical-dotnet/master/assets/diacritical.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/Diacritical/Diacritical.csproj
+++ b/Diacritical/Diacritical.csproj
@@ -13,7 +13,7 @@
 		<Product>Diacritical</Product>
     <PackageTags>diacritic;string-formatting;accent</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/anth12/diacritical-dotnet/master/assets/diacritical.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/Diacritical/StringBuilderCache.cs
+++ b/Diacritical/StringBuilderCache.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Text;
+
+namespace Diacritical
+{
+
+    /// <summary>
+    /// .net5 implementation
+    /// </summary>
+    internal static class StringBuilderCache
+    {
+        // The value 360 was chosen in discussion with performance experts as a compromise between using
+        // as little memory per thread as possible and still covering a large part of short-lived
+        // StringBuilder creations on the startup path of VS designers.
+        internal const int MaxBuilderSize = 360;
+        private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity
+
+        [ThreadStatic] private static StringBuilder t_cachedInstance;
+
+        /// <summary>Get a StringBuilder for the specified capacity.</summary>
+        /// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
+        public static StringBuilder Acquire(int capacity = DefaultCapacity)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                StringBuilder sb = t_cachedInstance;
+                if (sb != null)
+                {
+                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // when the requested size is larger than the current capacity
+                    if (capacity <= sb.Capacity)
+                    {
+                        t_cachedInstance = null;
+                        sb.Clear();
+                        return sb;
+                    }
+                }
+            }
+
+            return new StringBuilder(capacity);
+        }
+
+        /// <summary>Place the specified builder in the cache if it is not too big.</summary>
+        public static void Release(StringBuilder sb)
+        {
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                t_cachedInstance = sb;
+            }
+        }
+
+        /// <summary>ToString() the stringbuilder, Release it to the cache, and return the resulting string.</summary>
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            string result = sb.ToString();
+            Release(sb);
+            return result;
+        }
+    }
+}

--- a/Diacritical/StringExtensions.cs
+++ b/Diacritical/StringExtensions.cs
@@ -9,20 +9,21 @@ namespace Diacritical
 			if (string.IsNullOrEmpty(source))
 				return source;
 
-			DiacriticIndex index = DiacriticMap.Index.Value;
+			DiacriticIndex index = DiacriticMap.Index;
 			var result = new StringBuilder(source.Length);
-			
-			foreach (char character in source)
-			{
-				if (index.Map.TryGetValue(character, out string replacement))
-				{
-					result.Append(replacement);
-				}
-				else
-				{
-					result.Append(character);
-				}
-			}
+
+            string replacement;
+			foreach (var character in source)
+            {
+                if (index.Map.TryGetValue(character, out replacement))
+                {
+                    result.Append(replacement);
+                }
+                else
+                {
+                    result.Append(character);
+                }
+            }
 
 			return result.ToString();
 		}
@@ -32,12 +33,11 @@ namespace Diacritical
 			if (string.IsNullOrEmpty(source))
 				return false;
 
-			DiacriticIndex index = DiacriticMap.Index.Value;
-			var result = new StringBuilder(source.Length);
+			DiacriticIndex index = DiacriticMap.Index;
 
 			foreach (char character in source)
 			{
-				if (index.Map.TryGetValue(character, out string replacement))
+				if (index.Map.ContainsKey(character))
 				{
 					return true;
 				}

--- a/Diacritical/StringExtensions.cs
+++ b/Diacritical/StringExtensions.cs
@@ -4,18 +4,17 @@ namespace Diacritical
 {
 	public static class StringExtensions
 	{
-		public static string RemoveDiacritics(this string source)
-		{
-			if (string.IsNullOrEmpty(source))
-				return source;
+        public static string RemoveDiacritics(this string source)
+        {
+            if (string.IsNullOrEmpty(source))
+                return source;
 
-			DiacriticIndex index = DiacriticMap.Index;
-			var result = new StringBuilder(source.Length);
+            DiacriticIndex index = DiacriticMap.Index;
+            var result = StringBuilderCache.Acquire(source.Length);
 
-            string replacement;
-			foreach (var character in source)
+            foreach (var character in source)
             {
-                if (index.Map.TryGetValue(character, out replacement))
+                if (index.Map.TryGetValue(character, out var replacement))
                 {
                     result.Append(replacement);
                 }
@@ -25,8 +24,8 @@ namespace Diacritical
                 }
             }
 
-			return result.ToString();
-		}
+            return StringBuilderCache.GetStringAndRelease(result);
+        }
 
 		public static bool HasDiacritics(this string source)
 		{
@@ -35,7 +34,7 @@ namespace Diacritical
 
 			DiacriticIndex index = DiacriticMap.Index;
 
-			foreach (char character in source)
+			foreach (var character in source)
 			{
 				if (index.Map.ContainsKey(character))
 				{

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,7 +36,7 @@ Sample mappings
 
 A full list of supported mappings can be found [here][default provider].
 
-Custom mappings can easily be added with a custom `IDiacriticProvider` implementation and registered with:
+Custom mappings can easily be added with a custom `IDiacriticProvider` implementation and registered using:
 
 ```c#
 DiacriticMap.AddProvider(new MyCustomDiacriticProvider());

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,15 +5,15 @@
 <img src="https://raw.githubusercontent.com/anth12/diacritical-dotnet/master/assets/diacritical.png" alt="Diacritical logo" width="256px" align="right">
 
 [![Build Status](https://anthonyhalliday.visualstudio.com/Diacritical/_apis/build/status/anth12.diacritical-dotnet?branchName=master)](https://anthonyhalliday.visualstudio.com/Diacritical/_build/latest?definitionId=1&branchName=master)
-![Nuget](https://img.shields.io/nuget/v/Diacritical.Net)
+![Nuget](https://img.shields.io/nuget/v/Diacritical.Net)(https://www.nuget.org/packages/Diacritical.Net/)
 
 ## Getting Started
 
 Install the ([nuget][nuget]):
 
-    PM> Install-Package DotDiacritic
+    PM> Install-Package Diacritical.Net
 
-	> dotnet add package DotDiacritic
+	> dotnet add package Diacritical.Net
 
 Usage
 
@@ -47,6 +47,6 @@ DiacriticMap.AddProvider(new MyCustomDiacriticProvider());
 - Diacritic mappings from [diacritics/database][diacritics database]
 
 
-[nuget]: https://www.nuget.org/packages/DotDiacritic/
+[nuget]: https://www.nuget.org/packages/Diacritical.Net/
 [diacritics database]: https://github.com/diacritics/database
 [default provider]: https://github.com/anth12/diacritical-dotnet/blob/master/DotDiacritic/DefaultDiacriticProvider.cs

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -50,4 +50,4 @@ DiacriticMap.AddProvider(new MyCustomDiacriticProvider());
 
 [nuget]: https://www.nuget.org/packages/Diacritical.Net/
 [diacritics database]: https://github.com/diacritics/database
-[default provider]: https://github.com/anth12/diacritical-dotnet/blob/master/DotDiacritic/DefaultDiacriticProvider.cs
+[default provider]: https://github.com/anth12/diacritical-dotnet/blob/master/Diacritical/DefaultDiacriticProvider.cs

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,7 +5,8 @@
 <img src="https://raw.githubusercontent.com/anth12/diacritical-dotnet/master/assets/diacritical.png" alt="Diacritical logo" width="256px" align="right">
 
 [![Build Status](https://anthonyhalliday.visualstudio.com/Diacritical/_apis/build/status/anth12.diacritical-dotnet?branchName=master)](https://anthonyhalliday.visualstudio.com/Diacritical/_build/latest?definitionId=1&branchName=master)
-![Nuget](https://img.shields.io/nuget/v/Diacritical.Net)(https://www.nuget.org/packages/Diacritical.Net/)
+[![Nuget](https://img.shields.io/nuget/v/Diacritical.Net)](https://www.nuget.org/packages/Diacritical.Net)
+
 
 ## Getting Started
 
@@ -36,7 +37,7 @@ Sample mappings
 
 A full list of supported mappings can be found [here][default provider].
 
-Custom mappings can easily be added with a custom `IDiacriticProvider` implementation and registered using:
+Custom mappings can easily be added with a custom `IDiacriticProvider` implementation and registered with:
 
 ```c#
 DiacriticMap.AddProvider(new MyCustomDiacriticProvider());

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,12 @@ steps:
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2
+  displayName: 'Restore nuget packages'
   inputs:
     restoreSolution: '$(solution)'
 
 - task: VSBuild@1
+  displayName: 'Build'
   inputs:
     solution: '$(solution)'
     msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactStagingDirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site"'
@@ -30,11 +32,14 @@ steps:
     configuration: '$(buildConfiguration)'
 
 - task: VSTest@2
+  displayName: 'Unit tests'
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
 - task: NuGetCommand@2
+  displayName: 'Publish to nuget.org'
+  continueOnError: true
   inputs:
     command: 'push'
     packagesToPush: '**/*.nupkg;'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ steps:
 
 - task: VSTest@2
   displayName: 'Unit tests'
+  continueOnError: false
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'


### PR DESCRIPTION
Add the .net5/6 implementation of string builder cache for speed / memory usage improvements
Update packages / target frameworks
Removed Newtonsoft in favour of System included deserializer
Benchmarks for comparison

```
|                                   Method |        Mean |      Error |    StdDev | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------------- |------------:|-----------:|----------:|-----:|-------:|------:|------:|----------:|
|             Diacritical_ShortLatinString |    88.72 ns |   6.018 ns |  0.330 ns |    2 | 0.0288 |     - |     - |     136 B |
|              Diacritical_LongLatinString | 4,519.68 ns | 463.055 ns | 25.382 ns |    9 | 0.3662 |     - |     - |    1728 B |
|         Diacritical_ShortDiacriticString |   181.63 ns |   2.579 ns |  0.141 ns |    5 | 0.0372 |     - |     - |     176 B |
|          Diacritical_LongDiacriticString | 6,758.00 ns | 111.667 ns |  6.121 ns |   11 | 0.5493 |     - |     - |    2592 B |
|     Diacritical_ShortLatinString_SbCache |    85.98 ns |   2.570 ns |  0.141 ns |    1 | 0.0085 |     - |     - |      40 B |
|      Diacritical_LongLatinString_SbCache | 4,198.34 ns |  75.236 ns |  4.124 ns |    8 | 0.3662 |     - |     - |    1728 B |
| Diacritical_ShortDiacriticString_SbCache |   170.13 ns |  11.456 ns |  0.628 ns |    4 | 0.0136 |     - |     - |      64 B |
|  Diacritical_LongDiacriticString_SbCache | 6,602.56 ns | 433.360 ns | 23.754 ns |   10 | 0.5493 |     - |     - |    2592 B |
```